### PR TITLE
Add a workaround for the "the input device is not a TTY" issue

### DIFF
--- a/.github/workflows/build-branch-image.yml
+++ b/.github/workflows/build-branch-image.yml
@@ -10,6 +10,9 @@ name: Build branch image
       - .github/workflows/build-branch-image.yml
     branches:
       - main
+  pull_request:
+    paths:
+      - .github/workflows/build-branch-image.yml
 
 jobs:
   build-branch-image:
@@ -25,7 +28,9 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: git clone --depth 1 --branch ${{ matrix.branch }} https://github.com/gardenlinux/gardenlinux.git
-      - run: make openstack BUILDKEY=info@23technologies.cloud
+      - name: Build image
+        shell: 'script -q -e -c "bash {0}"'
+        run: make openstack BUILDKEY=info@23technologies.cloud
         working-directory: gardenlinux
       - run: mkdir gardenlinux/.build/openstack/upload
       - run: sudo apt-get install -y qemu-utils

--- a/.github/workflows/build-release-image.yml
+++ b/.github/workflows/build-release-image.yml
@@ -8,6 +8,9 @@ name: Build release image
       - .github/workflows/build-release-image.yml
     branches:
       - main
+  pull_request:
+    paths:
+      - .github/workflows/build-release-image.yml
 
 jobs:
   build-release-image:
@@ -23,7 +26,9 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: git clone --depth 1 --branch ${{ matrix.release }} https://github.com/gardenlinux/gardenlinux.git
-      - run: make openstack BUILDKEY=info@23technologies.cloud
+      - name: Build image
+        shell: 'script -q -e -c "bash {0}"'
+        run: make openstack BUILDKEY=info@23technologies.cloud
         working-directory: gardenlinux
       - run: mkdir gardenlinux/.build/openstack/upload
       - run: sudo apt-get install -y qemu-utils


### PR DESCRIPTION
Caused by the use of -ti in the upstream.

make --directory=cert MAINTAINER_EMAIL="contact@gardenlinux.io"
make[1]: Entering directory '/home/runner/work/openstack-gardenlinux-image/openstack-gardenlinux-image/gardenlinux/cert'
Building cfssl / cfssljson
the input device is not a TTY
make[1]: *** [Makefile:82: cfssl/cfssl] Error 1

Signed-off-by: Christian Berendt <berendt@23technologies.cloud>